### PR TITLE
Fix #17 Rake task to update corona stats

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'html-proofer'
 require 'jekyll'
+require_relative 'lib/corona_stats.rb'
 
 multitask default: %i[link_check clean]
 
@@ -29,4 +30,11 @@ task :link_check => [:build] do
   rescue => msg
     puts "#{msg}"
   end
+end
+
+desc 'Update Corona Stats'
+task :update_corona_stats do
+  include CoronaStats
+
+  CoronaStats.update(ENV['world'], ENV['nepal'])
 end

--- a/_data/corona_stats.yml
+++ b/_data/corona_stats.yml
@@ -1,18 +1,19 @@
+---
 np:
   world:
-    confirmed: १६,३२,६४
-    deaths: ९७,५८३
-    recovered: ३,६६,५८७
+    confirmed: १७,२२,५१४
+    deaths: १,०४,७७५
+    recovered: ३,८९,२९२
   nepal:
     confirmed: ९
-    deaths: 0
+    deaths: ०
     recovered: १
 en:
   world:
-    confirmed: 16,32,614
-    deaths: 97,583
-    recovered: 366,587
+    confirmed: '17,22,514'
+    deaths: '1,04,775'
+    recovered: '3,89,292'
   nepal:
-    confirmed: 9
-    deaths: 0
-    recovered: 1
+    confirmed: '9'
+    deaths: '0'
+    recovered: '1'

--- a/lib/corona_stats.rb
+++ b/lib/corona_stats.rb
@@ -1,0 +1,68 @@
+require 'yaml'
+
+STATS_PATH = "#{File.expand_path('../../', __FILE__)}/_data/corona_stats.yml"
+
+module CoronaStats
+   ENG_NP_NUMS = {
+      "0" => '०', "1" => '१', "2" => '२', "3" => '३', "4" => '४',
+      "5" => '५', "6" => '६', "7" => '७', "8" => '८', "9" => '९'
+   }
+   @stats_hash = {}
+   @confirmed, @deaths, @recovered = ""
+   @np_confirmed, @np_deaths, @np_recovered = ""
+
+   def nepali_format(num)
+      num.split('').map do |e|
+         if e == ","
+           e
+         else
+            ENG_NP_NUMS[e]
+         end
+      end.join
+   end
+
+   def load_stats_hash
+      @stats_hash = YAML.load_file(STATS_PATH)
+   end
+
+   def update_stats_variables(world, nepal)
+      @confirmed, @deaths, @recovered = world.split(':')
+      @np_confirmed, @np_deaths, @np_recovered = nepal.split(':')
+   end
+
+   def update_english_stats
+      @stats_hash["en"]["world"] = {
+         "confirmed" => @confirmed, "deaths" => @deaths, "recovered" => @recovered
+      }
+      @stats_hash["en"]["nepal"] = {
+         "confirmed" => @np_confirmed, "deaths" => @np_deaths, "recovered" => @np_recovered
+      }
+   end
+
+   def update_nepali_stats
+      @stats_hash["np"]["world"] = {
+         "confirmed" => nepali_format(@confirmed),
+         "deaths" => nepali_format(@deaths),
+         "recovered" => nepali_format(@recovered)
+      }
+      @stats_hash["np"]["nepal"] = {
+         "confirmed" => nepali_format(@np_confirmed),
+         "deaths" => nepali_format(@np_deaths),
+         "recovered" => nepali_format(@np_recovered)
+      }
+   end
+
+   def update_corona_stats_file
+      File.open(STATS_PATH, 'w') do |h|
+         h.write @stats_hash.to_yaml
+      end
+   end
+
+   def update(world, nepal)
+      load_stats_hash
+      update_stats_variables(world, nepal)
+      update_english_stats
+      update_nepali_stats
+      update_corona_stats_file
+   end
+end


### PR DESCRIPTION
We can now update the corona stats by the following command.

```
rake update_corona_stats world="17,22,514:1,04,775:3,89,292" nepal="9:0:1"
```

It has updated the file `_data/corona_stats.yml` as:
```
---
np:
  world:
    confirmed: १७,२२,५१४
    deaths: १,०४,७७५
    recovered: ३,८९,२९२
  nepal:
    confirmed: ९
    deaths: ०
    recovered: १
en:
  world:
    confirmed: '17,22,514'
    deaths: '1,04,775'
    recovered: '3,89,292'
  nepal:
    confirmed: '9'
    deaths: '0'
    recovered: '1'
```